### PR TITLE
Replaces ambiguous checkbox

### DIFF
--- a/includes/helium_exporter.form.inc
+++ b/includes/helium_exporter.form.inc
@@ -77,7 +77,7 @@ function helium_exporter_form($form, &$form_state) {
         <strong>%s:</strong> %d <span class="helium-exporter-selections"></span>
         <span class="helium-exporter-field-options">
           <a href="#" alt="Search a value" title="Search a value">Search</a> | 
-          <a class="helium-exporter-item-check" href="#" alt="Select or deselect all options" title="Select or deselect all options">All</a>
+          <input type="checkbox">&nbsp;Select All
         </span>
         <div class="helium-exporter-custom-checkbox-search">
           <input type="text" value="">

--- a/theme/script/script-helium-exporter-page.js
+++ b/theme/script/script-helium-exporter-page.js
@@ -99,12 +99,11 @@
       //
 
       // Add event listener to select and deselect option.
-      $('.helium-exporter-field-options a:last-child')
+      $('.helium-exporter-field-options input[type="checkbox"]')
         .click(function(e) {
-          e.preventDefault();
           // Current item selected.
           var element = $(this);
-            
+          
           // Identify which custom checkbox set to affect event
           // and reference components to use.
           var customCheckboxSet = customCheckboxGetSet(element);
@@ -113,8 +112,8 @@
           // Set state of item (check or uncheck).
           // Elements: class to remove, class to add.
           var checkClass = [];
-
-          if (element.hasClass(checkState.on)) {
+          
+          if (element.is(':checked')) {
             // Item select all. OFF to ON (all).
             checkClass.push(checkState.on, checkState.off);
 
@@ -126,12 +125,7 @@
             checkClass.push(checkState.off, checkState.on);
             checkTable[ customCheckboxSet ] = [];
           }
-            
-          // Apply class to show state of item.
-          element
-            .removeClass(checkClass[0])
-            .addClass(checkClass[1]);
-            
+
           items
             .removeClass(checkClass[1])
             .addClass(checkClass[0]);


### PR DESCRIPTION
This PR replaces ambiguous checkbox as described in issue #5 Control select and deselect all.

![image](https://user-images.githubusercontent.com/15472253/213281364-bfb6682a-cb4b-40be-a5fe-63110cde2d57.png)

TO TEST:
1. Pull changes to this module.
2. Switch to branch - ambiguous-checkbox
3. Clear cache
4. Click select and deselect form element