### PR TITLE
Adds alternative view

### DIFF
--- a/helium_exporter.module
+++ b/helium_exporter.module
@@ -95,7 +95,8 @@ function helium_exporter_preprocess_helium_exporter_form(&$variables, $hook) {
   $variables['helium_resource'] = array(
     'download' => 'https://github.com/cardinalb/helium-docs/wiki/Download-Helium',
     'information' => 'https://github.com/cardinalb/helium-docs/wiki',
-    'help' => 'https://github.com/cardinalb/helium-docs/wiki/Data-Formats'
+    'help' => 'https://github.com/cardinalb/helium-docs/wiki/Data-Formats',
+    'web-base' => 'https://helium.hutton.ac.uk', 
   );
 }
 

--- a/theme/helium_exporter_page.tpl.php
+++ b/theme/helium_exporter_page.tpl.php
@@ -21,7 +21,7 @@
       <h2>Visualize plant pedigrees and overlay categorical data using Helium:</h2>
       <p>
         Helium is a generic platform in which various data types can be shown in a pedigree context.&nbsp;&nbsp;<a id="helium-exporter-show" href="#">Show me how</a><br />
-        <a href="<?php print $helium_resource['download']; ?>" target="_blank">Download Helium</a> | <a href="<?php print $helium_resource['information']; ?>" target="_blank">More Information</a>
+        <a href="<?php print $helium_resource['download']; ?>" target="_blank">Download Helium</a> | <a href="<?php print $helium_resource['web-base']; ?>" target="_blank">Web-based Helium</a> | <a href="<?php print $helium_resource['information']; ?>" target="_blank">More Information</a>
       </p>
       
       <div id="helium-exporter-show-window">
@@ -33,6 +33,7 @@
             <p>
               Download and install Helium viewer application in your computer. Please use the link below and select an operating system.
               <a href="<?php print $helium_resource['download']; ?>">&#xbb; Download and install Helium</a>
+              <a href="<?php print $helium_resource['web-base']; ?>">&#xbb; or use the Web-based Helium</a>
             </p>
           </div>
 


### PR DESCRIPTION
Issue #7 

This PR updates the usage diagram to include the web-based Helium as an alternative to the desktop version of Helium

![image](https://github.com/UofS-Pulse-Binfo/helium_exporter/assets/15472253/999e0265-52ae-4d5a-9a99-91d0402682ba)


Note; I have verified that the web-based version now supports our custom relationship types (ie. is selection of) as mentioned in the issue.

To test, access the Helium Exporter page and click on the two links shown in the screenshot above to make sure that both will point to this site/web application:

![image](https://github.com/UofS-Pulse-Binfo/helium_exporter/assets/15472253/c136e69c-f9d3-4423-a2cd-8b066c43c061)
